### PR TITLE
fixed error with empty arrays

### DIFF
--- a/src/report/issues.ts
+++ b/src/report/issues.ts
@@ -7,10 +7,10 @@ import {
   gatherValuesPerMonth,
 } from "../util";
 import { IssuesMetrics } from "./types";
-import { calculateDaysBetweenDates } from "./utils";
+import { calculateDaysBetweenDates, toTotalMetrics } from "./utils";
 
 export class IssueAnalytics {
-  constructor(private readonly logger: ActionLogger) {}
+  constructor(private readonly logger: ActionLogger) { }
 
   getAnalytics(issues: IssueNode[]): IssuesMetrics {
     const monthlyTotals = this.generateMonthlyTotals(issues);
@@ -120,18 +120,9 @@ export class IssueAnalytics {
         ),
       );
     return {
-      comments: {
-        median: Math.round(median(totalComments)),
-        average: Math.round(average(totalComments)),
-      },
-      closeTime: {
-        median: Math.round(median(totalCloseTime)),
-        average: Math.round(average(totalCloseTime)),
-      },
-      timeToFirstComment: {
-        median: Math.round(median(totalTimeToFirstComment)),
-        average: Math.round(average(totalTimeToFirstComment)),
-      },
+      comments: toTotalMetrics(totalComments),
+      closeTime: toTotalMetrics(totalCloseTime),
+      timeToFirstComment: toTotalMetrics(totalTimeToFirstComment),
     };
   }
 }

--- a/src/report/issues.ts
+++ b/src/report/issues.ts
@@ -1,5 +1,3 @@
-import { average, median } from "simple-statistics";
-
 import { ActionLogger, IssueNode } from "../github/types";
 import {
   calculateEventsPerMonth,
@@ -10,7 +8,7 @@ import { IssuesMetrics } from "./types";
 import { calculateDaysBetweenDates, toTotalMetrics } from "./utils";
 
 export class IssueAnalytics {
-  constructor(private readonly logger: ActionLogger) { }
+  constructor(private readonly logger: ActionLogger) {}
 
   getAnalytics(issues: IssueNode[]): IssuesMetrics {
     const monthlyTotals = this.generateMonthlyTotals(issues);

--- a/src/report/pullRequests.ts
+++ b/src/report/pullRequests.ts
@@ -1,5 +1,4 @@
 import moment from "moment";
-import { average, median } from "simple-statistics";
 
 import { ActionLogger, PullRequestNode } from "../github/types";
 import {
@@ -151,9 +150,9 @@ export class PullRequestAnalytics {
           : undefined,
         review: timeToFirstReview
           ? {
-            date: firstReview as string,
-            daysSinceCreation: timeToFirstReview,
-          }
+              date: firstReview as string,
+              daysSinceCreation: timeToFirstReview,
+            }
           : undefined,
         additions: pr.additions,
         deletions: pr.deletions,

--- a/src/report/pullRequests.ts
+++ b/src/report/pullRequests.ts
@@ -8,6 +8,7 @@ import {
   gatherValuesPerMonth,
 } from "../util";
 import { DurationWithInitialDate, PullRequestMetrics, Reviewer } from "./types";
+import { toTotalMetrics } from "./utils";
 
 interface PullRequestInfo {
   number: number;
@@ -150,9 +151,9 @@ export class PullRequestAnalytics {
           : undefined,
         review: timeToFirstReview
           ? {
-              date: firstReview as string,
-              daysSinceCreation: timeToFirstReview,
-            }
+            date: firstReview as string,
+            daysSinceCreation: timeToFirstReview,
+          }
           : undefined,
         additions: pr.additions,
         deletions: pr.deletions,
@@ -289,18 +290,9 @@ export class PullRequestAnalytics {
       .map((v) => v / 24);
     const reviewsTotal = prs.map((pr) => pr.reviews);
     return {
-      mergeTime: {
-        median: Math.round(median(mergeTimeTotal)),
-        average: Math.round(average(mergeTimeTotal)),
-      },
-      reviews: {
-        median: Math.round(median(reviewsTotal)),
-        average: Math.round(average(reviewsTotal)),
-      },
-      timeToFirstReview: {
-        median: Math.round(median(timeToFirstTotal)),
-        average: Math.round(average(timeToFirstTotal)),
-      },
+      mergeTime: toTotalMetrics(mergeTimeTotal),
+      reviews: toTotalMetrics(reviewsTotal),
+      timeToFirstReview: toTotalMetrics(timeToFirstTotal),
     };
   }
 }

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -61,8 +61,8 @@ export interface IssuesMetrics {
 }
 
 export type MonthWithMatch = [string, number];
-export type MonthMetrics = { month: string; median: number; average: number };
 export type TotalMetrics = { median: number; average: number };
+export type MonthMetrics = TotalMetrics & { month: string };
 
 export type DurationWithInitialDate = {
   date: string;

--- a/src/report/types.ts
+++ b/src/report/types.ts
@@ -61,7 +61,7 @@ export interface IssuesMetrics {
 }
 
 export type MonthWithMatch = [string, number];
-export type TotalMetrics = { median: number; average: number };
+export type TotalMetrics = { median: number | null; average: number | null };
 export type MonthMetrics = TotalMetrics & { month: string };
 
 export type DurationWithInitialDate = {

--- a/src/report/utils.ts
+++ b/src/report/utils.ts
@@ -1,6 +1,7 @@
 import moment from "moment";
-import { TotalMetrics } from "./types";
 import { average, median } from "simple-statistics";
+
+import { TotalMetrics } from "./types";
 
 /** Return the difference of two dates as a positive integer */
 export const calculateDaysBetweenDates = (
@@ -12,12 +13,12 @@ export const toTotalMetrics = (metrics: number[]): TotalMetrics => {
   if (metrics.length > 0) {
     return {
       median: Math.round(median(metrics)),
-      average: Math.round(average(metrics))
+      average: Math.round(average(metrics)),
     };
   }
 
   return {
     median: -1,
-    average: -1
-  }
-}
+    average: -1,
+  };
+};

--- a/src/report/utils.ts
+++ b/src/report/utils.ts
@@ -18,7 +18,7 @@ export const toTotalMetrics = (metrics: number[]): TotalMetrics => {
   }
 
   return {
-    median: -1,
-    average: -1,
+    median: null,
+    average: null,
   };
 };

--- a/src/report/utils.ts
+++ b/src/report/utils.ts
@@ -1,7 +1,23 @@
 import moment from "moment";
+import { TotalMetrics } from "./types";
+import { average, median } from "simple-statistics";
 
 /** Return the difference of two dates as a positive integer */
 export const calculateDaysBetweenDates = (
   date1: string,
   date2: string,
 ): number => Math.abs(moment(date2).diff(date1, "days"));
+
+export const toTotalMetrics = (metrics: number[]): TotalMetrics => {
+  if (metrics.length > 0) {
+    return {
+      median: Math.round(median(metrics)),
+      average: Math.round(average(metrics))
+    };
+  }
+
+  return {
+    median: -1,
+    average: -1
+  }
+}

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -278,7 +278,8 @@ gantt
   ${months
     .map(
       ({ month, median, average }) =>
-        `section ${month}\n    Average ${average} : 0, ${average}\n    Median ${median} : 0, ${median}`,
+        (median + average > -1) ?
+          `section ${month}\n    Average ${average} : 0, ${average}\n    Median ${median} : 0, ${median}` : "",
     )
     .join("\n    ")}
 \`\`\``;

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -276,10 +276,10 @@ gantt
   dateFormat X
   axisFormat %s
   ${months
-    .map(
-      ({ month, median, average }) =>
-        (median + average > -1) ?
-          `section ${month}\n    Average ${average} : 0, ${average}\n    Median ${median} : 0, ${median}` : "",
+    .map(({ month, median, average }) =>
+      median + average > -1
+        ? `section ${month}\n    Average ${average} : 0, ${average}\n    Median ${median} : 0, ${median}`
+        : "",
     )
     .join("\n    ")}
 \`\`\``;

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -44,14 +44,14 @@ const generatePrSummary = (
         dateFormat  X
         axisFormat %s
         section To close
-        Average ${prMetrics.totalMetrics.mergeTime.average} : 0, ${prMetrics.totalMetrics.mergeTime.average}
-        Median ${prMetrics.totalMetrics.mergeTime.median} : 0, ${prMetrics.totalMetrics.mergeTime.median}
+        Average ${prMetrics.totalMetrics.mergeTime.average ?? "NO DATA"} : 0, ${prMetrics.totalMetrics.mergeTime.average ?? 0}
+        Median ${prMetrics.totalMetrics.mergeTime.median ?? "NO DATA"} : 0, ${prMetrics.totalMetrics.mergeTime.median ?? 0}
         section To first review
-        Average ${prMetrics.totalMetrics.timeToFirstReview.average} : 0, ${prMetrics.totalMetrics.timeToFirstReview.average}
-        Median ${prMetrics.totalMetrics.timeToFirstReview.median} : 0, ${prMetrics.totalMetrics.timeToFirstReview.median}
+        Average ${prMetrics.totalMetrics.timeToFirstReview.average ?? "NO DATA"} : 0, ${prMetrics.totalMetrics.timeToFirstReview.average ?? 0}
+        Median ${prMetrics.totalMetrics.timeToFirstReview.median ?? "NO DATA"} : 0, ${prMetrics.totalMetrics.timeToFirstReview.median ?? 0}
         section Reviews per PR
-        Average ${prMetrics.totalMetrics.reviews.average} : 0, ${prMetrics.totalMetrics.reviews.average}
-        Median ${prMetrics.totalMetrics.reviews.median} : 0, ${prMetrics.totalMetrics.reviews.median}
+        Average ${prMetrics.totalMetrics.reviews.average ?? "NO DATA"} : 0, ${prMetrics.totalMetrics.reviews.average ?? 0}
+        Median ${prMetrics.totalMetrics.reviews.median ?? "NO DATA"} : 0, ${prMetrics.totalMetrics.reviews.median ?? 0}
   \`\`\``;
 
   text = text
@@ -183,14 +183,14 @@ const generateIssueSummary = (
         dateFormat  X
         axisFormat %s
         section Time to close
-        Median ${issueMetrics.totalMetrics.closeTime.median} : 0, ${issueMetrics.totalMetrics.closeTime.median}
-        Average ${issueMetrics.totalMetrics.closeTime.average} : 0, ${issueMetrics.totalMetrics.closeTime.average}
+        Median ${issueMetrics.totalMetrics.closeTime.median ?? "NO DATA"} : 0, ${issueMetrics.totalMetrics.closeTime.median ?? 0}
+        Average ${issueMetrics.totalMetrics.closeTime.average ?? "NO DATA"} : 0, ${issueMetrics.totalMetrics.closeTime.average ?? 0}
         section Time to first comment
-        Median ${issueMetrics.totalMetrics.timeToFirstComment.median} : 0, ${issueMetrics.totalMetrics.timeToFirstComment.median}
-        Average ${issueMetrics.totalMetrics.timeToFirstComment.average} : 0, ${issueMetrics.totalMetrics.timeToFirstComment.average}
+        Median ${issueMetrics.totalMetrics.timeToFirstComment.median ?? "NO DATA"} : 0, ${issueMetrics.totalMetrics.timeToFirstComment.median ?? 0}
+        Average ${issueMetrics.totalMetrics.timeToFirstComment.average ?? "NO DATA"} : 0, ${issueMetrics.totalMetrics.timeToFirstComment.average ?? 0}
         section Average comments per issue
-        Median ${issueMetrics.totalMetrics.comments.median} : 0, ${issueMetrics.totalMetrics.comments.median}
-        Average ${issueMetrics.totalMetrics.comments.average} : 0, ${issueMetrics.totalMetrics.comments.average}
+        Median ${issueMetrics.totalMetrics.comments.median ?? 0} : 0, ${issueMetrics.totalMetrics.comments.median ?? 0}
+        Average ${issueMetrics.totalMetrics.comments.average ?? 0} : 0, ${issueMetrics.totalMetrics.comments.average ?? 0}
   \`\`\``;
 
   text = text
@@ -277,7 +277,7 @@ gantt
   axisFormat %s
   ${months
     .map(({ month, median, average }) =>
-      median + average > -1
+      median && average
         ? `section ${month}\n    Average ${average} : 0, ${average}\n    Median ${median} : 0, ${median}`
         : "",
     )

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,7 @@ import { average, median } from "simple-statistics";
 
 import { ActionLogger } from "./github/types";
 import { MonthMetrics, MonthWithMatch } from "./report/types";
+import { toTotalMetrics } from "./report/utils";
 
 export function generateCoreLogger(): ActionLogger {
   return { info, debug, warn: warning, error };
@@ -94,8 +95,7 @@ export const gatherValuesPerMonth = <T extends { date: string }>(
       // We push the previous match and reset it
       monthsWithMatches.push({
         month: currentMonth.format("MMM YYYY"),
-        median: Math.round(median(currentMonthValues)),
-        average: Math.round(average(currentMonthValues)),
+        ...toTotalMetrics(currentMonthValues)
       });
 
       // We change the currentMonth variable to the following one

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,5 @@
 import { debug, error, info, warning } from "@actions/core";
 import moment from "moment";
-import { average, median } from "simple-statistics";
 
 import { ActionLogger } from "./github/types";
 import { MonthMetrics, MonthWithMatch } from "./report/types";
@@ -95,7 +94,7 @@ export const gatherValuesPerMonth = <T extends { date: string }>(
       // We push the previous match and reset it
       monthsWithMatches.push({
         month: currentMonth.format("MMM YYYY"),
-        ...toTotalMetrics(currentMonthValues)
+        ...toTotalMetrics(currentMonthValues),
       });
 
       // We change the currentMonth variable to the following one


### PR DESCRIPTION
Fixed the error `Error: quantile requires at least one data point` when inputing an empty array.

Now empty arrays return -1 which is ignored by the reporter