### PR TITLE
Get user's report for multiple repositories

### DIFF
--- a/.github/workflows/generate-repo-metrics.yml
+++ b/.github/workflows/generate-repo-metrics.yml
@@ -30,8 +30,7 @@ jobs:
         id: metric
         with:
           GITHUB_TOKEN: ${{ github.token }}
-          owner: ${{ github.event.inputs.org }}
-          repo: ${{ github.event.inputs.repo }}
+          repo: ${{ github.event.inputs.org }}/${{ github.event.inputs.repo }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/generate-user-metrics.yml
+++ b/.github/workflows/generate-user-metrics.yml
@@ -38,12 +38,3 @@ jobs:
           owner: ${{ github.event.inputs.org }}
           repo: ${{ github.event.inputs.repo }}
           author: ${{ github.event.inputs.user }}
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/generate-user-metrics.yml
+++ b/.github/workflows/generate-user-metrics.yml
@@ -5,16 +5,11 @@ on:
     branches: ["main"]
   workflow_dispatch:
     inputs:
-      org:
-        description: "Organization"
-        type: string
-        required: false
-        default: "polkadot-fellows"
       repo:
-        description: "Repository"
+        description: "Repositories separated by comma"
         type: string
         required: false
-        default: "runtimes"
+        default: "paritytech/metrics"
       user:
         description: "User"
         type: string
@@ -35,6 +30,5 @@ jobs:
         id: metric
         with:
           GITHUB_TOKEN: ${{ github.token }}
-          owner: ${{ github.event.inputs.org }}
           repo: ${{ github.event.inputs.repo }}
           author: ${{ github.event.inputs.user }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN yarn install --immutable --mode skip-build
 
 COPY . .
 
-RUN yarn postinstall
-
 RUN yarn run build
 
 FROM node:22-slim

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # GitHub metrics
 
-Get GitHub metrics for a repository.
+Get GitHub metrics for a repository or a user.
 
 Supports obtaining metrics from:
 
 - Pull Requests
 - Issues
-
-It also supports obtaining user metrics related to a repository.
 
 ## To start
 
@@ -22,6 +20,7 @@ If the repository is private you will need to enable the `repo` option.
 Copy `example.env` as `.env` and replace the variables with your own.
 
 > If you want to get a user's related metric, write their username in the `AUTHOR` field, if not, just leave it empty.
+> You can get user metrics for more than one repository by filling the `REPO` field with the desired repos separated by a comma (`org/repo1,org/repo2,org/repo3`).
 
 Run:
 
@@ -43,6 +42,7 @@ And select `Run workflow` to run the system in this repository.
 After a couple of minutes, the [GitHub action summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) will contain all the results.
 
 You can also use the user metrics workflow here: [![Fetch user metrics](https://github.com/paritytech/metrics/actions/workflows/generate-user-metrics.yml/badge.svg)](https://github.com/paritytech/metrics/actions/workflows/generate-user-metrics.yml)
+> You can get user metrics for more than one repository by filling the `REPO` field with the desired repos separated by a comma (`org/repo1,org/repo2,org/repo3`).
 
 #### Install in your own repository
 
@@ -75,10 +75,7 @@ jobs:
   - If the repo is public, or is the same repo where the action is being executed, you can use `${{ github.token }}`
   - If the repo is big (more than 700 PRs), or it is a different private repo you need to use a [Personal Access Token](https://github.com/settings/tokens) with `public_repo` enabled.
     - This is required because the action's token will hit it's limit before finishing crawling the repository data.
-- `owner`: Name of the owner of the repository.
-  - **Optional**.
-  - Defaults to the owner/organization who is running the action.
-- `repo`: Name of the repository to crawl.
+- `repo`: Name of the repository to crawl in `owner/repo`.
   - **Optional**.
   - Default to the repository's name where this action is running.
 - `author`: Username of the account to obtain metrics

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,7 @@ inputs:
     description: The token to access the repo
   repo:
     required: false
-    description: The repo to fetch the information from. Defaults to runner
-  owner:
-    required: false
-    description: The owner of the repo to fetch the information from. Defaults to the runner of the action
+    description: Name of the repository in style org/name. Defaults to runner. Can have multiple values separated by comma if it's used for user's metrics
   author:
     required: false
     description: Optional. If we want the metrics of a specific user.

--- a/example.env
+++ b/example.env
@@ -1,4 +1,3 @@
 GITHUB_TOKEN="PAT with public_repo"
-OWNER="paritytech"
-REPO="metrics"
+REPO="paritytech/metrics"
 AUTHOR=""

--- a/src/github/repository.ts
+++ b/src/github/repository.ts
@@ -107,7 +107,6 @@ export class RepositoryApi {
       ISSUE_LIST_QUERY,
       this.repo,
       (query) => {
-        console.log(query.repository);
         if (!query.repository?.issues) {
           throw new Error("query.repository.issues is empty!");
         }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -9,7 +9,7 @@ export interface ActionLogger {
   error(message: string | Error): void;
 }
 
-export type Repo = {owner:string; repo:string};
+export type Repo = { owner: string; repo: string };
 
 export type GitHubClient = InstanceType<typeof GitHub>;
 

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -9,6 +9,8 @@ export interface ActionLogger {
   error(message: string | Error): void;
 }
 
+export type Repo = {owner:string; repo:string};
+
 export type GitHubClient = InstanceType<typeof GitHub>;
 
 export type Author = { login: string };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,8 @@ const getRepo = (ctx: Context): Repo[] => {
 
   const repos = repo.split(",");
   return repos.map((owner_repo) => {
-    const [owner, repo] = owner_repo.split("/");
-    return { owner, repo };
+    const [owner, repository] = owner_repo.split("/");
+    return { owner, repo: repository };
   });
 };
 
@@ -44,8 +44,8 @@ const token = getInput("GITHUB_TOKEN", { required: true });
 const logger = generateCoreLogger();
 if (author) {
   getUserMetrics(getOctokit(token), logger, repo, author)
-    .then(async ({ summary }) => {
-      await writeOutputFile(summary, `Report for ${author}`);
+    .then(async (report) => {
+      await writeOutputFile(report.summary, `Report for ${author}`);
     })
     .catch(setFailed);
 } else {

--- a/src/report/user.ts
+++ b/src/report/user.ts
@@ -22,9 +22,7 @@ export class UserAnalytics {
     private readonly logger: ActionLogger,
     private readonly author: string,
   ) {
-    logger.debug(
-      `Reporter has been configured for ${author}'s contribution`,
-    );
+    logger.debug(`Reporter has been configured for ${author}'s contribution`);
   }
 
   private isAuthor(author?: Author | null): boolean {

--- a/src/report/user.ts
+++ b/src/report/user.ts
@@ -20,11 +20,10 @@ export interface UserMetrics {
 export class UserAnalytics {
   constructor(
     private readonly logger: ActionLogger,
-    repo: { owner: string; repo: string },
     private readonly author: string,
   ) {
     logger.debug(
-      `Reporter has been configured for ${author}'s contribution in ${repo.owner}/${repo.repo}`,
+      `Reporter has been configured for ${author}'s contribution`,
     );
   }
 

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,13 +1,13 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import { summary } from "@actions/core";
 
+import { Repo } from "./github/types";
 import {
   IssuesMetrics,
   MonthMetrics,
   PullRequestMetrics,
 } from "./report/types";
 import { UserMetrics } from "./report/user";
-import { Repo } from "./github/types";
 
 export const generateSummary = (
   repo: { owner: string; repo: string },
@@ -294,10 +294,10 @@ export const generateUserSummary = (
   repos: Repo[],
   metrics: UserMetrics,
 ): typeof summary => {
-  let text = summary.addHeading(
-    `Metrics for @${author}`,
-    1,
-  ).addHeading("Repos used", 3).addList(repos.map(({owner,repo}) =>`<code>${owner}/${repo}</code>`));
+  let text = summary
+    .addHeading(`Metrics for @${author}`, 1)
+    .addHeading("Repos used", 3)
+    .addList(repos.map(({ owner, repo }) => `<code>${owner}/${repo}</code>`));
 
   text = text
     .addHeading("Pull Request Metrics", 2)

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -7,6 +7,7 @@ import {
   PullRequestMetrics,
 } from "./report/types";
 import { UserMetrics } from "./report/user";
+import { Repo } from "./github/types";
 
 export const generateSummary = (
   repo: { owner: string; repo: string },
@@ -290,13 +291,13 @@ gantt
 
 export const generateUserSummary = (
   author: string,
-  repo: { owner: string; repo: string },
+  repos: Repo[],
   metrics: UserMetrics,
 ): typeof summary => {
   let text = summary.addHeading(
-    `Metrics for @${author} in <code>${repo.owner}/${repo.repo}</code>`,
+    `Metrics for @${author}`,
     1,
-  );
+  ).addHeading("Repos used", 3).addList(repos.map(({owner,repo}) =>`<code>${owner}/${repo}</code>`));
 
   text = text
     .addHeading("Pull Request Metrics", 2)


### PR DESCRIPTION
Added ability to list more than one repository for user metrics. The system now accepts a new input of `owner/repo` style, and if more repos are added they have to be separated by a comma.

Resolves #21

If the repo metrics are invoked, the system will only use the first repo, ignoring any other available repos.

The repo information is still being cached in `.cache` and are combined on runtime to generate a bigger sample.

- [x] Updated readme